### PR TITLE
changes that can reproduce httpmime lib missing error of indexer web app

### DIFF
--- a/fcrepo-jms-indexer-webapp/pom.xml
+++ b/fcrepo-jms-indexer-webapp/pom.xml
@@ -69,7 +69,19 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-
+<!--  HttpClient are used for create standardalone SolrIndexer Server client.
+         They are not included with Solr 3.6.2
+         use Ver 4.2.5 aim to meet JENA lib: jena-fuseki included version, but still httpmime is not found by classpath -->
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.2.5</version>
+      </dependency>
+      <dependency>
+       <groupId>org.apache.httpcomponents</groupId>
+       <artifactId>httpmime</artifactId>
+       <version>4.2.5</version>
+      </dependency>
   </dependencies>
 
   <build>

--- a/fcrepo-jms-indexer-webapp/src/main/resources/spring/indexer-core.xml
+++ b/fcrepo-jms-indexer-webapp/src/main/resources/spring/indexer-core.xml
@@ -30,14 +30,27 @@
   <bean id="fileSerializer" class="org.fcrepo.indexer.FileSerializer">
     <property name="path" value="${file.serializer.dir:./target/test-classes/fileSerializer/}"/>
   </bean>
-
+<!-- Solr Indexer -->
+  <bean id="solrIndexer" class="org.fcrepo.indexer.SolrIndexer">
+    <constructor-arg ref="solrServer" />
+  </bean>
+  <!--Standardalone Server  -->
+  <bean id="solrServer" class="org.apache.solr.client.solrj.impl.HttpSolrServer">
+     <constructor-arg index="0" value="http://localhost:${solr.port:8983}/solr/" />
+  </bean>
+  
   <!-- Message Driven POJO (MDP) that manages individual indexers -->
   <bean id="indexerGroup" class="org.fcrepo.indexer.IndexerGroup">
-    <property name="repositoryURL" value="http://${fcrepo.host:localhost}:${fcrepo.port:8080}/rest" />
+    <property name="repositoryURL" value="http://${fcrepo.host:localhost}:${fcrepo.port:8080}/fcrepo-webapp-4.0.0-alpha-1/rest" />
     <property name="indexers">
       <set>
-        <ref bean="fileSerializer"/>
-        <ref bean="sparqlUpdate"/>
+      <!-- Comments other indexers to make solrIndexer error easy to find -->
+<!--         <ref bean="fileSerializer"/> -->
+<!--         <ref bean="sparqlUpdate"/> -->
+<!--Expect error: cannot resolve reference to bean 'solrServer' while setting constructor argument ....
+nested exception is java.lang.NoClassDefFoundError: org/apache/http/entity/mime/content/ContentBody
+   -->
+          <ref bean="solrIndexer"/>
       </set>
     </property>
   </bean>


### PR DESCRIPTION
httpmime lib included file is said missing to run fcrepo-jms-indexer-webapp:
java.lang.NoClassDefFoundError: org/apache/http/entity/mime/content/ContentBody

I tried to add httpmime into fcrepo-jms-indexer-webapp/pom.xml as the code show below, but the error still exist.
*httpmime is included in JENA lib"jena-fuseki" in fcrepo-jms-indexer-core/pom.xml.
I wonder if I could make solr as separated project fro JENA indexer to avoid possbile libs conflict like jetty-server and httpmine?
*Lucene 3.6.2 is included in modeshape. So solr server version cannot be freely chosen:
 <parent>
    <groupId>org.fcrepo</groupId>
    <artifactId>fcrepo</artifactId>
    <version>4.0.0-alpha-3-SNAPSHOT</version>
  </parent>
I wonder if fcrepo-jms-indexer-pluggable project can remove dependence from fcrepo4, so solr indexer can be free?
