### PR TITLE
logic to remove prop from id for prop changed events

### DIFF
--- a/fcrepo-jms-indexer-core/src/main/java/org/fcrepo/indexer/IndexerGroup.java
+++ b/fcrepo-jms-indexer-core/src/main/java/org/fcrepo/indexer/IndexerGroup.java
@@ -23,6 +23,7 @@ import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
 import static com.hp.hpl.jena.vocabulary.RDF.type;
 import static java.lang.Integer.MAX_VALUE;
 import static javax.jcr.observation.Event.NODE_REMOVED;
+import static javax.jcr.observation.Event.PROPERTY_CHANGED;
 import static org.fcrepo.kernel.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -84,6 +85,12 @@ public class IndexerGroup implements MessageListener {
      */
     private static final String REMOVAL_EVENT_TYPE = REPOSITORY_NAMESPACE
             + EventType.valueOf(NODE_REMOVED).toString();
+
+    /**
+     * Type of event that qualifies as a propert change.
+     */
+    private static final String PROPERTY_CHANGED_EVENT_TYPE = REPOSITORY_NAMESPACE
+            + EventType.valueOf(PROPERTY_CHANGED).toString();
 
     public static final String INDEXER_NAMESPACE =
         "http://fedora.info/definitions/v4/indexing#";
@@ -167,7 +174,12 @@ public class IndexerGroup implements MessageListener {
 
             final Boolean removal = REMOVAL_EVENT_TYPE.equals(eventType);
             LOGGER.debug("It is {} that this is a removal operation.", removal);
-            final String uri = getRepositoryURL() + pid;
+            final Boolean property_changed = PROPERTY_CHANGED_EVENT_TYPE.equals(eventType);
+            LOGGER.debug("It is {} that this is a property_change operation.", property_changed);
+            String uri = getRepositoryURL() + pid;
+            if (property_changed) {
+                uri = uri.substring(0,uri.lastIndexOf("/"));
+            }
             final RdfRetriever rdfr = new RdfRetriever(uri, httpClient);
             final NamedFieldsRetriever nfr =
                 new NamedFieldsRetriever(uri, httpClient, rdfr);


### PR DESCRIPTION
curl -X PATCH -H "Content-Type: application/sparql-update" "http://localhost:8080/rest/test1/indexableObj2" -d "@sparqlupdate.txt"
PREFIX rdf: http://www.w3.org./1999/02/22-rdf-syntax-ns#
PREFIX dc: http://purl.org/dc/elements/1.1/
INSERT {  
  <> rdf:type  http://purl.org/dc/elements/1.1/describable ;
  dc:title "update3-some-resource-title" ;
  dc:creator "some3-resource-creator"
}
WHERE { }

Results in 1 prop changed events with id "/test1/indexableObj2/dc:title". Check for this condition and remove property.
