### PR TITLE
Updated SolrIndexer to commit upon update.

### DIFF
--- a/fcrepo-jms-indexer-core/src/main/java/org/fcrepo/indexer/solr/SolrIndexer.java
+++ b/fcrepo-jms-indexer-core/src/main/java/org/fcrepo/indexer/solr/SolrIndexer.java
@@ -108,6 +108,7 @@ public class SolrIndexer extends AsynchIndexer<NamedFields, UpdateResponse> {
                                 resp.getStatus(), id);
                     }
                     LOGGER.debug("Received result from Solr request.");
+                    server.commit();
                     return resp;
                 } catch (final SolrServerException | IOException e) {
                     LOGGER.error("Update exception: {}!", e);


### PR DESCRIPTION
This is likely fixed by a prior pull request, but given the time constraints of this release, this is a bare minimum diff that should be easy to review and (with the last pull request) is enough that I can say with some confidence that the code works such that updates in fedora can be wired to result in updates to a solr index.
