### PR TITLE
accept fcr:transform responses as JSON arrays

### DIFF
--- a/fcrepo-message-consumer-core/src/main/java/org/fcrepo/indexer/NamedFieldsDeserializer.java
+++ b/fcrepo-message-consumer-core/src/main/java/org/fcrepo/indexer/NamedFieldsDeserializer.java
@@ -45,7 +45,7 @@ import com.google.gson.stream.JsonWriter;
  */
 public class NamedFieldsDeserializer extends TypeAdapter<NamedFields> {
 
-    private static final Type type = new TypeToken<Map<String, JsonElement>>() {}
+    private static final Type type = new TypeToken<List<Map<String, JsonElement>>>() {}
             .getType();
 
     private Gson gson;
@@ -80,10 +80,10 @@ public class NamedFieldsDeserializer extends TypeAdapter<NamedFields> {
     public NamedFields read(final JsonReader in)
         throws IOException {
         try {
-            final Map<String, JsonElement> fields = gson.fromJson(in, type);
-            return new NamedFields(transformValues(fields, jsonElement2list));
+            final List<Map<String, JsonElement>> fields = gson.fromJson(in, type);
+            return new NamedFields(transformValues(fields.get(0), jsonElement2list));
         } catch (final Exception e) {
-            LOGGER.error("Failed to parse JSON to Map<String, Collection<String>>!", e);
+            LOGGER.error("Failed to parse JSON to List<Map<String, Collection<String>>>!", e);
             throw e;
         }
 

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/NamedFieldsDeserializerTest.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/NamedFieldsDeserializerTest.java
@@ -43,7 +43,7 @@ public class NamedFieldsDeserializerTest {
     @Test
     public void testReadGoodJson() throws IOException {
         final String testUri = "testUri";
-        final String fakeJson = "{\"id\" : [\"" + testUri + "\"]}";
+        final String fakeJson = "[{\"id\" : [\"" + testUri + "\"]}]";
         LOGGER.debug("Using fake JSON: {}", fakeJson);
         try (
             Reader r = new StringReader(fakeJson);
@@ -57,7 +57,7 @@ public class NamedFieldsDeserializerTest {
     @Test(expected = IllegalStateException.class)
     public void testReadBadJson() throws IOException {
         final String testUri = "testUri";
-        final String fakeJson = "{\"id\" : \"" + testUri + "\"}";
+        final String fakeJson = "[{\"id\" : \"" + testUri + "\"}]";
         LOGGER.debug("Using fake JSON: {}", fakeJson);
         try (
             Reader r = new StringReader(fakeJson);

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/NamedFieldsRetrieverTest.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/NamedFieldsRetrieverTest.java
@@ -137,7 +137,7 @@ public class NamedFieldsRetrieverTest {
         when(mockClient.execute(any(HttpUriRequest.class))).thenReturn(
                 mockResponse);
         when(mockStatusLine.getStatusCode()).thenReturn(SC_OK);
-        final String fakeJson = "{\"id\" : [\"" + testUri + "\"]}";
+        final String fakeJson = "[{\"id\" : [\"" + testUri + "\"]}]";
         LOGGER.debug("Using fake JSON: {}", fakeJson);
         try (
             InputStream mockJson =


### PR DESCRIPTION
As per PR #618 https://github.com/fcrepo4/fcrepo4/pull/618, accept fcr:transform responses as JSON arrays rather than as single JSON objects.
