### PR TITLE
migrated support for the indexing# namespace to config#

### DIFF
--- a/fcrepo-message-consumer-core/src/main/java/org/fcrepo/indexer/IndexerGroup.java
+++ b/fcrepo-message-consumer-core/src/main/java/org/fcrepo/indexer/IndexerGroup.java
@@ -116,21 +116,21 @@ public class IndexerGroup implements MessageListener {
     private static final String REINDEX_EVENT_TYPE = REPOSITORY_NAMESPACE
             + "NODE_REINDEXED";
 
-    public static final String INDEXER_NAMESPACE =
-        "http://fedora.info/definitions/v4/indexing#";
+    public static final String CONFIG_NAMESPACE =
+        "http://fedora.info/definitions/v4/config#";
 
     /**
      * Indicates the transformation to use with this resource to derive indexing
      * information.
      */
     public static final Property INDEXING_TRANSFORM_PREDICATE =
-        createProperty(INDEXER_NAMESPACE + "hasIndexingTransformation");
+        createProperty(CONFIG_NAMESPACE + "hasIndexingTransformation");
 
     /**
      * Indicates that a resource is indexable.
      */
     public static final Resource INDEXABLE_MIXIN =
-        createResource(INDEXER_NAMESPACE + "indexable");
+        createResource(CONFIG_NAMESPACE + "Indexable");
 
     private static final String REST_PREFIX = "/rest/";
     private static final String FCREPO_PREFIX = "/fcrepo/";

--- a/fcrepo-message-consumer-core/src/main/resources/indexing.cnd
+++ b/fcrepo-message-consumer-core/src/main/resources/indexing.cnd
@@ -1,5 +1,5 @@
-<indexing = 'http://fedora.info/definitions/v4/indexing#'>
+<config = 'http://fedora.info/definitions/v4/config#'>
 
-[indexing:indexable] mixin
-- indexing:hasIndexingTransformation (STRING) multiple COPY nofulltext noqueryorder
+[config:Indexable] mixin
+- config:hasIndexingTransformation (STRING) multiple COPY nofulltext noqueryorder
 

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/IndexerGroupTest.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/IndexerGroupTest.java
@@ -205,11 +205,11 @@ public class IndexerGroupTest {
                 "<http://fedora.info/definitions/v4/repository#Container> ;\n" +
                 "\t<http://fedora.info/definitions/v4/repository#primaryType> \"nt:folder\"^^<http://www.w3" +
                 ".org/2001/XMLSchema#string> ;\n" +
-                (indexerName != null ? "\t<http://fedora.info/definitions/v4/indexing#hasIndexingTransformation> \""
+                (indexerName != null ? "\t<http://fedora.info/definitions/v4/config#hasIndexingTransformation> \""
                         + indexerName + "\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n" : "") +
                 "\t<http://fedora.info/definitions/v4/repository#uuid> " +
                 "\"b1bfd6b8-b821-48c5-8eb9-05ef47e1b6e6\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n" +
-                "\ta " + (indexable ? "<http://fedora.info/definitions/v4/indexing#indexable> , " +
+                "\ta " + (indexable ? "<http://fedora.info/definitions/v4/config#Indexable> , " +
                 "" : "") + "<http://fedora.info/definitions/v4/repository#Resource> , " +
                 "<http://fedora.info/definitions/v4/repository#Container> .\n";
     }

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/integration/IndexerGroupIT.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/integration/IndexerGroupIT.java
@@ -71,9 +71,9 @@ public class IndexerGroupIT extends IndexingIT {
     private void createIndexableObject(final String uri) throws Exception {
         final String objectRdf =
             "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ."
-                    + "@prefix indexing:<http://fedora.info/definitions/v4/indexing#>."
-                    + "<" + uri + ">  rdf:type  <http://fedora.info/definitions/v4/indexing#indexable> ;"
-                    + "indexing:hasIndexingTransformation \"default\".";
+                    + "@prefix config:<http://fedora.info/definitions/v4/config#>."
+                    + "<" + uri + ">  rdf:type  <http://fedora.info/definitions/v4/config#Indexable> ;"
+                    + "config:hasIndexingTransformation \"default\".";
 
         createResource(uri, objectRdf, contentTypeN3Alt1);
         LOGGER.debug("Created object at: {}", uri);
@@ -170,7 +170,7 @@ public class IndexerGroupIT extends IndexingIT {
         final URI descURI = Link.valueOf(response.getFirstHeader("Link").getValue()).getUri();
         final HttpPatch patch = new HttpPatch(descURI);
         final String sparqlUpdate = "insert { <> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
-                + "<http://fedora.info/definitions/v4/indexing#indexable> } where {}";
+                + "<http://fedora.info/definitions/v4/config#Indexable> } where {}";
         patch.setEntity(new StringEntity(sparqlUpdate));
         patch.addHeader("Content-Type", "application/sparql-update");
         assertEquals(204, client.execute(patch).getStatusLine().getStatusCode());

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/system/SolrMappingsIT.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/system/SolrMappingsIT.java
@@ -83,12 +83,12 @@ public class SolrMappingsIT extends IndexingIT {
         final String objectRdf =
             "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ."
                     + "@prefix dc:<http://purl.org/dc/elements/1.1/> ."
-                    + "@prefix indexing:<http://fedora.info/definitions/v4/indexing#>."
+                    + "@prefix config:<http://fedora.info/definitions/v4/config#>."
                     + "<" + uri + ">  dc:title        \"500 Easy Microwave Meals\" ; "
                     + "dc:creator      \"Yubulac Xorhorisa\" ; "
                     + "dc:subject      \"goats\" ;"
-                    + "rdf:type  <http://fedora.info/definitions/v4/indexing#indexable> ;"
-                    + "indexing:hasIndexingTransformation \"default\".";
+                    + "rdf:type  <http://fedora.info/definitions/v4/config#Indexable> ;"
+                    + "config:hasIndexingTransformation \"default\".";
 
         createRequest.setEntity(new StringEntity(objectRdf));
         createRequest.addHeader("Content-Type", WebContent.contentTypeN3Alt1);
@@ -174,13 +174,13 @@ public class SolrMappingsIT extends IndexingIT {
         final String objectRdf =
             "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ."
                     + "@prefix dc:<http://purl.org/dc/elements/1.1/> ."
-                    + "@prefix indexing:<http://fedora.info/definitions/v4/indexing#>."
+                    + "@prefix config:<http://fedora.info/definitions/v4/config#>."
                     + "<" + uri + ">  dc:title        \"500 Easy Microwave Meals\" ; "
                     + "dc:creator      \"Yubulac Xorhorisa\" ; "
                     + "dc:subject      \"goats\" ;"
-                    + "rdf:type  <http://fedora.info/definitions/v4/indexing#indexable> ;"
+                    + "rdf:type  <http://fedora.info/definitions/v4/config#Indexable> ;"
                     + "rdf:type  <http://fedora.info/definitions/v4/indexingtest#book> ;"
-                    + "indexing:hasIndexingTransformation \"dc\".";
+                    + "config:hasIndexingTransformation \"dc\".";
 
         createRequest.setEntity(new StringEntity(objectRdf));
         createRequest.addHeader("Content-Type", contentTypeN3Alt1);

--- a/fcrepo-message-consumer-core/src/test/resources/rdf/dublin_core.n3
+++ b/fcrepo-message-consumer-core/src/test/resources/rdf/dublin_core.n3
@@ -1,9 +1,9 @@
 @prefix dc:<http://purl.org/dc/elements/1.1/> .
-@prefix indexing:<http://fedora.info/definitions/v4/indexing#>.
+@prefix config:<http://fedora.info/definitions/v4/config#>.
 @prefix rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 
 <>	dc:title		"Easy Microwave Meals For Ghouls" ;  
 	dc:creator		"Yubulac Xorhorisa" ; 
 	dc:subject		<http://id.loc.gov/authorities/subjects/sh2012004374> ;
-	rdf:type			<indexing:indexable> ;
-	indexing:hasIndexingTransformation "dc".
+	rdf:type			<config:Indexable> ;
+	config:hasIndexingTransformation "dc".


### PR DESCRIPTION
Related to https://jira.duraspace.org/browse/FCREPO-1285 and https://jira.duraspace.org/browse/FCREPO-1287

This adds support for the `config#` namespace, removing the deprecated `indexing#` namespace. It also renames `indexable` to `Indexable` as owl:Class types are generally capitalized.