### PR TITLE
update use of indexing namespace to correspond to proposed OWL-based defn

### DIFF
--- a/fcrepo-message-consumer-core/src/main/java/org/fcrepo/indexer/IndexerGroup.java
+++ b/fcrepo-message-consumer-core/src/main/java/org/fcrepo/indexer/IndexerGroup.java
@@ -130,7 +130,7 @@ public class IndexerGroup implements MessageListener {
      * Indicates that a resource is indexable.
      */
     public static final Resource INDEXABLE_MIXIN =
-        createResource(INDEXER_NAMESPACE + "indexable");
+        createResource(INDEXER_NAMESPACE + "Indexable");
 
     private static final String REST_PREFIX = "/rest/";
     private static final String FCREPO_PREFIX = "/fcrepo/";

--- a/fcrepo-message-consumer-core/src/main/resources/indexing.cnd
+++ b/fcrepo-message-consumer-core/src/main/resources/indexing.cnd
@@ -1,5 +1,5 @@
 <indexing = 'http://fedora.info/definitions/v4/indexing#'>
 
-[indexing:indexable] mixin
+[indexing:Indexable] mixin
 - indexing:hasIndexingTransformation (STRING) multiple COPY nofulltext noqueryorder
 

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/IndexerGroupTest.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/IndexerGroupTest.java
@@ -209,7 +209,7 @@ public class IndexerGroupTest {
                         + indexerName + "\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n" : "") +
                 "\t<http://fedora.info/definitions/v4/repository#uuid> " +
                 "\"b1bfd6b8-b821-48c5-8eb9-05ef47e1b6e6\"^^<http://www.w3.org/2001/XMLSchema#string> ;\n" +
-                "\ta " + (indexable ? "<http://fedora.info/definitions/v4/indexing#indexable> , " +
+                "\ta " + (indexable ? "<http://fedora.info/definitions/v4/indexing#Indexable> , " +
                 "" : "") + "<http://fedora.info/definitions/v4/repository#Resource> , " +
                 "<http://fedora.info/definitions/v4/repository#Container> .\n";
     }

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/integration/IndexerGroupIT.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/integration/IndexerGroupIT.java
@@ -72,7 +72,7 @@ public class IndexerGroupIT extends IndexingIT {
         final String objectRdf =
             "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ."
                     + "@prefix indexing:<http://fedora.info/definitions/v4/indexing#>."
-                    + "<" + uri + ">  rdf:type  <http://fedora.info/definitions/v4/indexing#indexable> ;"
+                    + "<" + uri + ">  rdf:type  <http://fedora.info/definitions/v4/indexing#Indexable> ;"
                     + "indexing:hasIndexingTransformation \"default\".";
 
         createResource(uri, objectRdf, contentTypeN3Alt1);
@@ -170,7 +170,7 @@ public class IndexerGroupIT extends IndexingIT {
         final URI descURI = Link.valueOf(response.getFirstHeader("Link").getValue()).getUri();
         final HttpPatch patch = new HttpPatch(descURI);
         final String sparqlUpdate = "insert { <> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
-                + "<http://fedora.info/definitions/v4/indexing#indexable> } where {}";
+                + "<http://fedora.info/definitions/v4/indexing#Indexable> } where {}";
         patch.setEntity(new StringEntity(sparqlUpdate));
         patch.addHeader("Content-Type", "application/sparql-update");
         assertEquals(204, client.execute(patch).getStatusLine().getStatusCode());

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/system/SolrMappingsIT.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/system/SolrMappingsIT.java
@@ -87,7 +87,7 @@ public class SolrMappingsIT extends IndexingIT {
                     + "<" + uri + ">  dc:title        \"500 Easy Microwave Meals\" ; "
                     + "dc:creator      \"Yubulac Xorhorisa\" ; "
                     + "dc:subject      \"goats\" ;"
-                    + "rdf:type  <http://fedora.info/definitions/v4/indexing#indexable> ;"
+                    + "rdf:type  <http://fedora.info/definitions/v4/indexing#Indexable> ;"
                     + "indexing:hasIndexingTransformation \"default\".";
 
         createRequest.setEntity(new StringEntity(objectRdf));
@@ -178,7 +178,7 @@ public class SolrMappingsIT extends IndexingIT {
                     + "<" + uri + ">  dc:title        \"500 Easy Microwave Meals\" ; "
                     + "dc:creator      \"Yubulac Xorhorisa\" ; "
                     + "dc:subject      \"goats\" ;"
-                    + "rdf:type  <http://fedora.info/definitions/v4/indexing#indexable> ;"
+                    + "rdf:type  <http://fedora.info/definitions/v4/indexing#Indexable> ;"
                     + "rdf:type  <http://fedora.info/definitions/v4/indexingtest#book> ;"
                     + "indexing:hasIndexingTransformation \"dc\".";
 

--- a/fcrepo-message-consumer-core/src/test/resources/rdf/dublin_core.n3
+++ b/fcrepo-message-consumer-core/src/test/resources/rdf/dublin_core.n3
@@ -5,5 +5,5 @@
 <>	dc:title		"Easy Microwave Meals For Ghouls" ;  
 	dc:creator		"Yubulac Xorhorisa" ; 
 	dc:subject		<http://id.loc.gov/authorities/subjects/sh2012004374> ;
-	rdf:type			<indexing:indexable> ;
+	rdf:type			<indexing:Indexable> ;
 	indexing:hasIndexingTransformation "dc".


### PR DESCRIPTION
This is related to https://jira.duraspace.org/browse/FCREPO-1285 and https://jira.duraspace.org/browse/FCREPO-1287

The proposed definition of an indexing# namespace uses a capitalized `Indexable` owl:class. This PR changes instances of `indexing:indexable` to `indexing:Indexable`.