### PR TITLE
fixed license comment in maven configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
     <license>
       <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-      <comments>Copyright (c) 2014 DuraSpace</comments>
+      <comments>Copyright (c) 2015 DuraSpace</comments>
     </license>
   </licenses>
   <distributionManagement>


### PR DESCRIPTION
See: https://jira.duraspace.org/browse/FCREPO-1297

I missed one license year declaration in the last pull request.