### PR TITLE
Rename dynamic build properties for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ indexer-core.xml
   <!-- sparql-update indexer -->
   <bean id="sparqlUpdate" class="org.fcrepo.indexer.SparqlIndexer">
     <!-- base URL for triplestore subjects, PID will be appended -->
-    <property name="prefix" value="http://localhost:${fcrepo.test.port:8080}/rest/objects/"/>
+    <property name="prefix" value="http://localhost:${fcrepo.dynamic.test.port:8080}/rest/objects/"/>
 
     <!-- fuseki (used by tests) -->
     <property name="queryBase" value="http://localhost:3030/test/query"/>
@@ -83,7 +83,7 @@ indexer-core.xml
 
   <!-- Message Driven POJO (MDP) that manages individual indexers -->
   <bean id="indexerGroup" class="org.fcrepo.indexer.IndexerGroup">
-    <property name="repositoryURL" value="http://localhost:${fcrepo.test.port:8080}/rest/objects/" />
+    <property name="repositoryURL" value="http://localhost:${fcrepo.dynamic.test.port:8080}/rest/objects/" />
     <property name="indexers">
       <set>
         <ref bean="sparqlUpdate"/>

--- a/fcrepo-message-consumer-core/pom.xml
+++ b/fcrepo-message-consumer-core/pom.xml
@@ -240,9 +240,9 @@
         <!-- reserve ports for integration tests -->
         <configuration>
           <portNames>
-            <portName>fcrepo.test.port</portName>
-            <portName>fuseki.test.mgt.port</portName>
-            <portName>fuseki.test.port</portName>
+            <portName>fcrepo.dynamic.test.port</portName>
+            <portName>fuseki.dynamic.test.mgt.port</portName>
+            <portName>fuseki.dynamic.test.port</portName>
           </portNames>
         </configuration>
         <executions>
@@ -263,9 +263,9 @@
         <configuration>
           <!-- export ports for integration tests to system.env-->
           <systemPropertyVariables>
-            <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
-            <fuseki.test.mgt.port>${fuseki.test.mgt.port}</fuseki.test.mgt.port>
-            <fuseki.test.port>${fuseki.test.port}</fuseki.test.port>
+            <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
+            <fuseki.dynamic.test.mgt.port>${fuseki.dynamic.test.mgt.port}</fuseki.dynamic.test.mgt.port>
+            <fuseki.dynamic.test.port>${fuseki.dynamic.test.port}</fuseki.dynamic.test.port>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/FusekiContainerWrapper.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/FusekiContainerWrapper.java
@@ -43,9 +43,9 @@ public class FusekiContainerWrapper extends ContainerWrapper {
     final private Logger logger = getLogger(FusekiContainerWrapper.class);
 
     private static final int FUSEKI_PORT = parseInt(getProperty(
-            "fuseki.test.port", "3030"));
+            "fuseki.dynamic.test.port", "3030"));
 
-    private static final int MGT_PORT = parseInt(getProperty("fuseki.test.mgt.port",
+    private static final int MGT_PORT = parseInt(getProperty("fuseki.dynamic.test.mgt.port",
             "3031"));
 
     private static final String serverAddress = "http://localhost:" + MGT_PORT

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/integration/sparql/SparqlIndexerITHelper.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/integration/sparql/SparqlIndexerITHelper.java
@@ -29,7 +29,8 @@ import static java.lang.System.getProperty;
  */
 public class SparqlIndexerITHelper {
 
-    private static String queryBase = "http://localhost:" + getProperty("fuseki.test.port", "3030") + "/test/query";
+    private static String queryBase =
+        "http://localhost:" + getProperty("fuseki.dynamic.test.port", "3030") + "/test/query";
 
     /**
      * No public constructor for utility class

--- a/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/system/IndexingIT.java
+++ b/fcrepo-message-consumer-core/src/test/java/org/fcrepo/indexer/system/IndexingIT.java
@@ -37,7 +37,7 @@ public abstract class IndexingIT {
 
     private static final Logger LOGGER = getLogger(IndexingIT.class);
 
-    protected static final int SERVER_PORT = parseInt(getProperty("fcrepo.test.port",
+    protected static final int SERVER_PORT = parseInt(getProperty("fcrepo.dynamic.test.port",
             "8080"));
 
     protected static final String serverAddress = "http://localhost:"

--- a/fcrepo-message-consumer-core/src/test/resources/spring-test/indexer-core.xml
+++ b/fcrepo-message-consumer-core/src/test/resources/spring-test/indexer-core.xml
@@ -12,9 +12,9 @@
 
     <!-- fuseki -->
     <property name="queryBase"
-      value="http://localhost:${fuseki.test.port:3030}/test/query"/>
+      value="http://localhost:${fuseki.dynamic.test.port:3030}/test/query"/>
     <property name="updateBase"
-      value="http://localhost:${fuseki.test.port:3030}/test/update"/>
+      value="http://localhost:${fuseki.dynamic.test.port:3030}/test/update"/>
     <property name="formUpdates">
       <value type="java.lang.Boolean">false</value>
     </property>

--- a/fcrepo-message-consumer-core/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-message-consumer-core/src/test/resources/spring-test/test-container.xml
@@ -8,7 +8,7 @@
   <context:property-placeholder/>
 
   <bean id="containerWrapper" class="org.fcrepo.indexer.FusekiContainerWrapper" init-method="start" destroy-method="stop" >
-    <property name="port" value="${fcrepo.test.port:8080}"/>
+    <property name="port" value="${fcrepo.dynamic.test.port:8080}"/>
     <property name="configLocation" value="classpath:web.xml" />
   </bean>
 

--- a/fcrepo-message-consumer-webapp/pom.xml
+++ b/fcrepo-message-consumer-webapp/pom.xml
@@ -179,8 +179,8 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
-            <fcrepo.jms.port>${fcrepo.jms.port}</fcrepo.jms.port>
+            <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
+            <fcrepo.dynamic.jms.port>${fcrepo.dynamic.jms.port}</fcrepo.dynamic.jms.port>
             <fcrepo.test.context.path>${fcrepo.test.context.path}</fcrepo.test.context.path>
           </systemPropertyVariables>
         </configuration>
@@ -190,11 +190,11 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <configuration>
           <portNames>
-            <portName>fcrepo.test.port</portName>
-            <portName>fcrepo.jms.port</portName>
+            <portName>fcrepo.dynamic.test.port</portName>
+            <portName>fcrepo.dynamic.jms.port</portName>
             <!-- reserves the stop port for jetty-maven-plugin -->
-            <portName>jetty.port.stop</portName>
-            <portName>fcrepo.stomp.port</portName>
+            <portName>jetty.dynamic.stop.port</portName>
+            <portName>fcrepo.dynamic.stomp.port</portName>
           </portNames>
         </configuration>
       </plugin>
@@ -223,20 +223,20 @@
             <configuration>
               <connectors>
                 <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                  <port>${fcrepo.test.port}</port>
+                  <port>${fcrepo.dynamic.test.port}</port>
                   <maxIdleTime>60000</maxIdleTime>
                 </connector>
               </connectors>
               <daemon>true</daemon>
-              <stopPort>${jetty.port.stop}</stopPort>
+              <stopPort>${jetty.dynamic.stop.port}</stopPort>
               <systemProperties>
                 <systemProperty>
-                  <name>fcrepo.jms.port</name>
-                  <value>${fcrepo.jms.port}</value>
+                  <name>fcrepo.dynamic.jms.port</name>
+                  <value>${fcrepo.dynamic.jms.port}</value>
                 </systemProperty>
                 <systemProperty>
-                  <name>fcrepo.stomp.port</name>
-                  <value>${fcrepo.stomp.port}</value>
+                  <name>fcrepo.dynamic.stomp.port</name>
+                  <value>${fcrepo.dynamic.stomp.port}</value>
                 </systemProperty>
               </systemProperties>
 
@@ -257,7 +257,7 @@
               <goal>stop</goal>
             </goals>
             <configuration>
-              <stopPort>${jetty.port.stop}</stopPort>
+              <stopPort>${jetty.dynamic.stop.port}</stopPort>
             </configuration>
           </execution>
         </executions>

--- a/fcrepo-message-consumer-webapp/src/main/resources/spring/indexer-events.xml
+++ b/fcrepo-message-consumer-webapp/src/main/resources/spring/indexer-events.xml
@@ -10,7 +10,7 @@
 
   <bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
     <!--The Reconnect query params allow the broker not to block on start-up-->
-    <property name="brokerURL" value="failover:(tcp://${fcrepo.jms.host:localhost}:${fcrepo.jms.port:61616})?startupMaxReconnectAttempts=1&amp;initialReconnectDelay=1"/>
+    <property name="brokerURL" value="failover:(tcp://${fcrepo.jms.host:localhost}:${fcrepo.dynamic.jms.port:61616})?startupMaxReconnectAttempts=1&amp;initialReconnectDelay=1"/>
   </bean>
 
   <!-- ActiveMQ queue to listen for events -->

--- a/fcrepo-message-consumer-webapp/src/test/java/org/fcrepo/indexer/integration/webapp/FedoraIndexerIT.java
+++ b/fcrepo-message-consumer-webapp/src/test/java/org/fcrepo/indexer/integration/webapp/FedoraIndexerIT.java
@@ -42,7 +42,7 @@ public class FedoraIndexerIT {
      * The server port of the application, set as system property by
      * maven-failsafe-plugin.
      */
-    private static final String SERVER_PORT = System.getProperty("fcrepo.test.port");
+    private static final String SERVER_PORT = System.getProperty("fcrepo.dynamic.test.port");
 
     /**
      * The context path of the application (including the leading "/"), set as

--- a/fcrepo-message-consumer-webapp/src/test/java/org/fcrepo/indexer/integration/webapp/SanityCheckIT.java
+++ b/fcrepo-message-consumer-webapp/src/test/java/org/fcrepo/indexer/integration/webapp/SanityCheckIT.java
@@ -47,7 +47,7 @@ public class SanityCheckIT {
      * The server port of the application, set as system property by
      * maven-failsafe-plugin.
      */
-    private static final String SERVER_PORT = System.getProperty("fcrepo.test.port");
+    private static final String SERVER_PORT = System.getProperty("fcrepo.dynamic.test.port");
 
     /**
      * The context path of the application (including the leading "/"), set as


### PR DESCRIPTION
The build-helper-maven-plugin is used to generate properties for dynamic
port configuration. This commit marks these properties with the word
`dynamic` to highlight that fact, e.g. `fcrepo.dynamic.test.port`.

Resolves: https://jira.duraspace.org/browse/FCREPO-1341