### PR TITLE
Connection problem (partial) fix

### DIFF
--- a/fcrepo-message-consumer-core/src/main/java/org/fcrepo/indexer/IndexerGroup.java
+++ b/fcrepo-message-consumer-core/src/main/java/org/fcrepo/indexer/IndexerGroup.java
@@ -32,6 +32,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
+//import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.fcrepo.kernel.utils.EventType;
 import org.slf4j.Logger;
 
@@ -54,7 +55,7 @@ import static com.google.common.base.Throwables.propagate;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createProperty;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
 import static com.hp.hpl.jena.vocabulary.RDF.type;
-import static java.lang.Integer.MAX_VALUE;
+//import static java.lang.Integer.MAX_VALUE;
 import static javax.jcr.observation.Event.NODE_REMOVED;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.fcrepo.kernel.FedoraJcrTypes.FCR_METADATA;
@@ -206,12 +207,13 @@ public class IndexerGroup implements MessageListener {
         }
 
         final PoolingClientConnectionManager connMann = new PoolingClientConnectionManager();
-        connMann.setMaxTotal(MAX_VALUE);
-        connMann.setDefaultMaxPerRoute(MAX_VALUE);
+        connMann.setMaxTotal(200);
+        connMann.setDefaultMaxPerRoute(20);
 
         final DefaultHttpClient httpClient = new DefaultHttpClient(connMann);
         httpClient.setRedirectStrategy(new DefaultRedirectStrategy());
         httpClient.setHttpRequestRetryHandler(new StandardHttpRequestRetryHandler(0, false));
+        //httpClient.setReuseStrategy(new NoConnectionReuseStrategy());
 
         // If the Fedora instance requires authentication, set it up here
         if (!isBlank(fedoraUsername) && !isBlank(fedoraPassword)) {


### PR DESCRIPTION
Make limits on maximum number of connections in pool.
Release connections after they are used.

This is regarding https://github.com/fcrepo4/fcrepo-message-consumer/issues/79.

It's not fully complete. The limits on the connection pool are currently just magic numbers; I assume you'd want to work that into configuration in whatever standard way you have of doing it.

The tests pass at this point, and the connections do not pile up.

I do, however (as noted in the JIRA ticket) now experience some items not being indexed. I don't know if this is because of problems in my code or if messages are being dropped somehow. I don't tend to see it until I start indexing around 5000-10000 things or so all at once.

I don't know if I'll look further - it's been suggested that we look into using the Camel integration instead. But since I already had this might as well send it along.